### PR TITLE
KX-7263 - Change codeowners to cm2 team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # Users referenced in this file will automatically be requested as reviewers for PRs that modify the given paths.
 # See https://help.github.com/articles/about-code-owners/
 
-* @Kentico/integration-team
+* @Kentico/content-management-2


### PR DESCRIPTION
### Motivation

Change codeowners to cm2 team.

### How to test

No testing.